### PR TITLE
ci: Use clippy (nightly) for linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ matrix:
     - env: SUITE=test
     - env: SUITE=format-check
       install: rustup component add rustfmt-preview
-    - env: SUITE=int
+    - env: SUITE=lint
       install: rustup component add clippy-preview
       rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,6 @@ matrix:
     - env: SUITE=test
     - env: SUITE=format-check
       install: rustup component add rustfmt-preview
+    - env: SUITE=int
+      install: rustup component add clippy-preview
+      rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,5 @@ sha-1 = "0.7.0"
 difference = "2.0.0"
 
 [patch.crates-io]
-#serde = { path = "../serde/serde" }
-#serde_derive = { path = "../serde/serde_derive" }
-serde = { git = "https://github.com/mitsuhiko/serde", rev = "e4eb33057e193e69e09cdc97074536486780c33d" }
-serde_derive = { git = "https://github.com/mitsuhiko/serde", rev = "e4eb33057e193e69e09cdc97074536486780c33d" }
+serde = { git = "https://github.com/mitsuhiko/serde", rev = "880a8c0181ad7202950f24cc8f6872994913441d" }
+serde_derive = { git = "https://github.com/mitsuhiko/serde", rev = "880a8c0181ad7202950f24cc8f6872994913441d" }

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ test: cargotest
 cargotest:
 	@cargo test --all-features
 
+format:
+	@cargo fmt
+
 format-check:
 	@cargo fmt -- --write-mode diff
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ extern crate sha1;
 extern crate sha2;
 extern crate uuid;
 
-#[allow(unused_imports)]
 #[macro_use]
 extern crate marshal_derive;
 

--- a/src/processor/chunk.rs
+++ b/src/processor/chunk.rs
@@ -43,7 +43,7 @@ pub fn chunks_from_str(text: &str, meta: &Meta) -> Vec<Chunk> {
 
     for remark in meta.remarks() {
         let (start, end) = match remark.range() {
-            Some(range) => range.clone(),
+            Some(range) => *range,
             None => continue,
         };
 

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -2,8 +2,8 @@
 
 mod builtin;
 mod chunk;
-mod processor;
+mod pii;
 mod rule;
 
-pub use self::processor::*;
+pub use self::pii::*;
 pub use self::rule::*;

--- a/src/protocol/meta.rs
+++ b/src/protocol/meta.rs
@@ -59,7 +59,7 @@ impl Remark {
     pub fn new<S: Into<String>>(ty: RemarkType, rule_id: S) -> Self {
         Remark {
             rule_id: rule_id.into(),
-            ty: ty,
+            ty,
             range: None,
         }
     }
@@ -68,7 +68,7 @@ impl Remark {
     pub fn with_range<S: Into<String>>(ty: RemarkType, rule_id: S, range: Range) -> Self {
         Remark {
             rule_id: rule_id.into(),
-            ty: ty,
+            ty,
             range: Some(range),
         }
     }
@@ -86,6 +86,11 @@ impl Remark {
     /// The length of this range.
     pub fn len(&self) -> Option<usize> {
         self.range.map(|r| r.1 - r.0)
+    }
+
+    /// Indicates if the remark refers to an empty range
+    pub fn is_empty(&self) -> bool {
+        self.len().map_or(false, |l| l == 0)
     }
 
     /// Returns the type.
@@ -331,6 +336,7 @@ impl<T> Annotated<T> {
     }
 
     /// Custom deserialize implementation that merges meta data from the deserializer.
+    #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
     pub fn deserialize_with<'de, D, C>(deserializer: D, _custom: C) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,

--- a/src/protocol/meta_ser.rs
+++ b/src/protocol/meta_ser.rs
@@ -703,10 +703,8 @@ impl SerializeStruct for SerializeStructMeta {
                     return Err(Error::custom("invalid annotated serialization field"));
                 }
             }
-        } else {
-            if let Some(tree) = value.serialize(MetaSerializer)? {
-                self.map.insert(key.to_string(), tree);
-            }
+        } else if let Some(tree) = value.serialize(MetaSerializer)? {
+            self.map.insert(key.to_string(), tree);
         }
 
         Ok(())

--- a/src/protocol/serde_chrono.rs
+++ b/src/protocol/serde_chrono.rs
@@ -83,7 +83,7 @@ impl CustomSerialize<DateTime<Utc>> for SerdeDateTime {
         if datetime.timestamp_subsec_nanos() == 0 {
             serializer.serialize_i64(datetime.timestamp())
         } else {
-            let micros = datetime.timestamp_subsec_micros() as f64 / 1_000_000f64;
+            let micros = f64::from(datetime.timestamp_subsec_micros()) / 1_000_000f64;
             serializer.serialize_f64(datetime.timestamp() as f64 + micros)
         }
     }

--- a/src/protocol/tracked.rs
+++ b/src/protocol/tracked.rs
@@ -8,7 +8,7 @@ fn state_with_parent_path<F: FnOnce(Rc<Path>) -> Rc<Path>>(state: &State, f: F) 
     let mut rv = state.clone();
     let parent = state
         .get::<Rc<Path>>()
-        .map(|x| x.clone())
+        .cloned()
         .unwrap_or_else(|| Rc::new(Path::Root));
     rv.set(f(parent));
     rv
@@ -80,10 +80,7 @@ pub struct TrackedDeserializer<D> {
 impl<D> TrackedDeserializer<D> {
     pub fn new(de: D, mut state: State) -> Self {
         state.set(Rc::new(Path::Root));
-        TrackedDeserializer {
-            de: de,
-            state: state,
-        }
+        TrackedDeserializer { de, state }
     }
 }
 
@@ -279,7 +276,7 @@ struct TrackedVisitor<X> {
 impl<X> TrackedVisitor<X> {
     fn new(delegate: X, state: &State) -> Self {
         TrackedVisitor {
-            delegate: delegate,
+            delegate,
             state: state.clone(),
         }
     }
@@ -476,10 +473,7 @@ struct CaptureKey<'a, X> {
 
 impl<'a, X> CaptureKey<'a, X> {
     fn new(delegate: X, key: &'a mut Option<String>) -> Self {
-        CaptureKey {
-            delegate: delegate,
-            key: key,
-        }
+        CaptureKey { delegate, key }
     }
 }
 
@@ -807,10 +801,7 @@ struct TrackedSeed<X> {
 
 impl<X> TrackedSeed<X> {
     fn new(seed: X, state: State) -> Self {
-        TrackedSeed {
-            seed: seed,
-            state: state,
-        }
+        TrackedSeed { seed, state }
     }
 }
 
@@ -838,7 +829,7 @@ struct SeqAccess<X> {
 impl<X> SeqAccess<X> {
     fn new(delegate: X, state: &State) -> Self {
         SeqAccess {
-            delegate: delegate,
+            delegate,
             state: state.clone(),
             index: 0,
         }
@@ -883,7 +874,7 @@ struct MapAccess<X> {
 impl<X> MapAccess<X> {
     fn new(delegate: X, state: &State) -> Self {
         MapAccess {
-            delegate: delegate,
+            delegate,
             state: state.clone(),
             key: None,
         }

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -66,33 +66,6 @@ impl fmt::Display for Level {
     }
 }
 
-impl Level {
-    /// A quick way to check if the level is `debug`.
-    pub fn is_debug(&self) -> bool {
-        *self == Level::Debug
-    }
-
-    /// A quick way to check if the level is `info`.
-    pub fn is_info(&self) -> bool {
-        *self == Level::Info
-    }
-
-    /// A quick way to check if the level is `warning`.
-    pub fn is_warning(&self) -> bool {
-        *self == Level::Warning
-    }
-
-    /// A quick way to check if the level is `error`.
-    pub fn is_error(&self) -> bool {
-        *self == Level::Error
-    }
-
-    /// A quick way to check if the level is `fatal`.
-    pub fn is_fatal(&self) -> bool {
-        *self == Level::Fatal
-    }
-}
-
 impl_str_serde!(Level);
 
 #[cfg(test)]
@@ -672,15 +645,15 @@ pub struct BrowserContext {
 #[derive(Debug, PartialEq)]
 pub enum Context {
     /// Device information.
-    Device(DeviceContext),
+    Device(Box<DeviceContext>),
     /// Operating system information.
-    Os(OsContext),
+    Os(Box<OsContext>),
     /// Runtime information.
-    Runtime(RuntimeContext),
+    Runtime(Box<RuntimeContext>),
     /// Application information.
-    App(AppContext),
+    App(Box<AppContext>),
     /// Web browser information.
-    Browser(BrowserContext),
+    Browser(Box<BrowserContext>),
     /// A context type that is unknown to this protocol specification.
     Other(String, Map<Value>),
 }
@@ -847,7 +820,7 @@ mod test_contexts {
   "timezone": "Europe/Vienna",
   "other": "value"
 }"#;
-        let context = Context::Device(DeviceContext {
+        let context = Context::Device(Box::new(DeviceContext {
             name: Some("iphone".to_string()).into(),
             family: Some("iphone".to_string()).into(),
             model: Some("iphone7,3".to_string()).into(),
@@ -873,7 +846,7 @@ mod test_contexts {
                 );
                 Annotated::from(map)
             },
-        });
+        }));
 
         assert_eq_dbg!(context, serde_json::from_str(json).unwrap());
         assert_eq_str!(json, serde_json::to_string_pretty(&context).unwrap());
@@ -882,7 +855,7 @@ mod test_contexts {
     #[test]
     fn test_device_default_values() {
         let json = r#"{"type":"device"}"#;
-        let context = Context::Device(DeviceContext {
+        let context = Context::Device(Box::new(DeviceContext {
             name: None.into(),
             family: None.into(),
             model: None.into(),
@@ -901,7 +874,7 @@ mod test_contexts {
             boot_time: None.into(),
             timezone: None.into(),
             other: Default::default(),
-        });
+        }));
 
         assert_eq_dbg!(context, serde_json::from_str(json).unwrap());
         assert_eq_str!(json, serde_json::to_string(&context).unwrap());
@@ -919,7 +892,7 @@ mod test_contexts {
   "raw_description": "iOS 11.4.2 FEEDFACE (17.4.0)",
   "other": "value"
 }"#;
-        let context = Context::Os(OsContext {
+        let context = Context::Os(Box::new(OsContext {
             name: Some("iOS".to_string()).into(),
             version: Some("11.4.2".to_string()).into(),
             build: Some("FEEDFACE".to_string()).into(),
@@ -934,7 +907,7 @@ mod test_contexts {
                 );
                 Annotated::from(map)
             },
-        });
+        }));
 
         assert_eq_dbg!(context, serde_json::from_str(json).unwrap());
         assert_eq_str!(json, serde_json::to_string_pretty(&context).unwrap());
@@ -943,7 +916,7 @@ mod test_contexts {
     #[test]
     fn test_os_default_values() {
         let json = r#"{"type":"os"}"#;
-        let context = Context::Os(OsContext {
+        let context = Context::Os(Box::new(OsContext {
             name: None.into(),
             version: None.into(),
             build: None.into(),
@@ -951,7 +924,7 @@ mod test_contexts {
             rooted: None.into(),
             raw_description: None.into(),
             other: Default::default(),
-        });
+        }));
 
         assert_eq_dbg!(context, serde_json::from_str(json).unwrap());
         assert_eq_str!(json, serde_json::to_string(&context).unwrap());
@@ -966,7 +939,7 @@ mod test_contexts {
   "raw_description": "rustc 1.27.0 stable",
   "other": "value"
 }"#;
-        let context = Context::Runtime(RuntimeContext {
+        let context = Context::Runtime(Box::new(RuntimeContext {
             name: Some("rustc".to_string()).into(),
             version: Some("1.27.0".to_string()).into(),
             raw_description: Some("rustc 1.27.0 stable".to_string()).into(),
@@ -978,7 +951,7 @@ mod test_contexts {
                 );
                 Annotated::from(map)
             },
-        });
+        }));
 
         assert_eq_dbg!(context, serde_json::from_str(json).unwrap());
         assert_eq_str!(json, serde_json::to_string_pretty(&context).unwrap());
@@ -987,12 +960,12 @@ mod test_contexts {
     #[test]
     fn test_runtime_default_values() {
         let json = r#"{"type":"runtime"}"#;
-        let context = Context::Runtime(RuntimeContext {
+        let context = Context::Runtime(Box::new(RuntimeContext {
             name: None.into(),
             version: None.into(),
             raw_description: None.into(),
             other: Default::default(),
-        });
+        }));
 
         assert_eq_dbg!(context, serde_json::from_str(json).unwrap());
         assert_eq_str!(json, serde_json::to_string(&context).unwrap());
@@ -1011,7 +984,7 @@ mod test_contexts {
   "app_build": "100001",
   "other": "value"
 }"#;
-        let context = Context::App(AppContext {
+        let context = Context::App(Box::new(AppContext {
             app_start_time: Some("2018-02-08T22:21:57Z".parse().unwrap()).into(),
             device_app_hash: Some("4c793e3776474877ae30618378e9662a".to_string()).into(),
             build_type: Some("testflight".to_string()).into(),
@@ -1027,7 +1000,7 @@ mod test_contexts {
                 );
                 Annotated::from(map)
             },
-        });
+        }));
 
         assert_eq_dbg!(context, serde_json::from_str(json).unwrap());
         assert_eq_str!(json, serde_json::to_string_pretty(&context).unwrap());
@@ -1036,7 +1009,7 @@ mod test_contexts {
     #[test]
     fn test_app_default_values() {
         let json = r#"{"type":"app"}"#;
-        let context = Context::App(AppContext {
+        let context = Context::App(Box::new(AppContext {
             app_start_time: None.into(),
             device_app_hash: None.into(),
             build_type: None.into(),
@@ -1045,7 +1018,7 @@ mod test_contexts {
             app_version: None.into(),
             app_build: None.into(),
             other: Default::default(),
-        });
+        }));
 
         assert_eq_dbg!(context, serde_json::from_str(json).unwrap());
         assert_eq_str!(json, serde_json::to_string(&context).unwrap());
@@ -1058,7 +1031,7 @@ mod test_contexts {
   "version": "67.0.3396.99",
   "other": "value"
 }"#;
-        let context = Context::Browser(BrowserContext {
+        let context = Context::Browser(Box::new(BrowserContext {
             name: Some("Google Chrome".to_string()).into(),
             version: Some("67.0.3396.99".to_string()).into(),
             other: {
@@ -1069,7 +1042,7 @@ mod test_contexts {
                 );
                 Annotated::from(map)
             },
-        });
+        }));
 
         assert_eq_dbg!(context, serde_json::from_str(json).unwrap());
         assert_eq_str!(json, serde_json::to_string_pretty(&context).unwrap());
@@ -1078,11 +1051,11 @@ mod test_contexts {
     #[test]
     fn test_browser_default_values() {
         let json = r#"{"type":"browser"}"#;
-        let context = Context::Browser(BrowserContext {
+        let context = Context::Browser(Box::new(BrowserContext {
             name: None.into(),
             version: None.into(),
             other: Default::default(),
-        });
+        }));
 
         assert_eq_dbg!(context, serde_json::from_str(json).unwrap());
         assert_eq_str!(json, serde_json::to_string(&context).unwrap());
@@ -2419,11 +2392,11 @@ pub struct ProguardDebugImage {
 pub enum DebugImage {
     /// Apple debug images (machos).  This is currently also used for non apple platforms with
     /// similar debug setups.
-    Apple(AppleDebugImage),
+    Apple(Box<AppleDebugImage>),
     /// Symbolic (new style) debug infos.
-    Symbolic(SymbolicDebugImage),
+    Symbolic(Box<SymbolicDebugImage>),
     /// A reference to a proguard debug file.
-    Proguard(ProguardDebugImage),
+    Proguard(Box<ProguardDebugImage>),
     /// A debug image that is unknown to this protocol specification.
     Other(String, Map<Value>),
 }
@@ -2550,7 +2523,7 @@ mod test_debug_image {
   "uuid": "395835f4-03e0-4436-80d3-136f0749a893",
   "other": "value"
 }"#;
-        let image = DebugImage::Proguard(ProguardDebugImage {
+        let image = DebugImage::Proguard(Box::new(ProguardDebugImage {
             uuid: "395835f4-03e0-4436-80d3-136f0749a893"
                 .parse::<Uuid>()
                 .unwrap()
@@ -2563,7 +2536,7 @@ mod test_debug_image {
                 );
                 Annotated::from(map)
             },
-        });
+        }));
 
         assert_eq_dbg!(image, serde_json::from_str(json).unwrap());
         assert_eq_str!(json, serde_json::to_string_pretty(&image).unwrap());
@@ -2584,7 +2557,7 @@ mod test_debug_image {
   "other": "value"
 }"#;
 
-        let image = DebugImage::Apple(AppleDebugImage {
+        let image = DebugImage::Apple(Box::new(AppleDebugImage {
             name: "CoreFoundation".to_string().into(),
             arch: Some("arm64".to_string()).into(),
             cpu_type: Some(1233).into(),
@@ -2604,7 +2577,7 @@ mod test_debug_image {
                 );
                 Annotated::from(map)
             },
-        });
+        }));
 
         assert_eq_dbg!(image, serde_json::from_str(json).unwrap());
         assert_eq_str!(json, serde_json::to_string_pretty(&image).unwrap());
@@ -2621,7 +2594,7 @@ mod test_debug_image {
   "uuid": "494f3aea-88fa-4296-9644-fa8ef5d139b6"
 }"#;
 
-        let image = DebugImage::Apple(AppleDebugImage {
+        let image = DebugImage::Apple(Box::new(AppleDebugImage {
             name: "CoreFoundation".to_string().into(),
             arch: None.into(),
             cpu_type: None.into(),
@@ -2634,7 +2607,7 @@ mod test_debug_image {
                 .unwrap()
                 .into(),
             other: Default::default(),
-        });
+        }));
 
         assert_eq_dbg!(image, serde_json::from_str(json).unwrap());
         assert_eq_str!(json, serde_json::to_string_pretty(&image).unwrap());
@@ -2653,7 +2626,7 @@ mod test_debug_image {
   "other": "value"
 }"#;
 
-        let image = DebugImage::Symbolic(SymbolicDebugImage {
+        let image = DebugImage::Symbolic(Box::new(SymbolicDebugImage {
             name: "CoreFoundation".to_string().into(),
             arch: Some("arm64".to_string()).into(),
             image_addr: Addr(0).into(),
@@ -2671,7 +2644,7 @@ mod test_debug_image {
                 );
                 Annotated::from(map)
             },
-        });
+        }));
 
         assert_eq_dbg!(image, serde_json::from_str(json).unwrap());
         assert_eq_str!(json, serde_json::to_string_pretty(&image).unwrap());
@@ -2688,7 +2661,7 @@ mod test_debug_image {
   "id": "494f3aea-88fa-4296-9644-fa8ef5d139b6-1234"
 }"#;
 
-        let image = DebugImage::Symbolic(SymbolicDebugImage {
+        let image = DebugImage::Symbolic(Box::new(SymbolicDebugImage {
             name: "CoreFoundation".to_string().into(),
             arch: None.into(),
             image_addr: Addr(0).into(),
@@ -2699,7 +2672,7 @@ mod test_debug_image {
                 .unwrap()
                 .into(),
             other: Default::default(),
-        });
+        }));
 
         assert_eq_dbg!(image, serde_json::from_str(json).unwrap());
         assert_eq_str!(json, serde_json::to_string_pretty(&image).unwrap());
@@ -3211,14 +3184,14 @@ mod event {
             Ok(Event {
                 id: id.unwrap_or_default(),
                 level: level.unwrap_or_default(),
-                fingerprint: fingerprint.unwrap_or_else(|| fingerprint::default()),
+                fingerprint: fingerprint.unwrap_or_else(fingerprint::default),
                 culprit: culprit.unwrap_or_default(),
                 transaction: transaction.unwrap_or_default(),
                 message: message.unwrap_or_default(),
                 logentry: logentry.unwrap_or_default(),
                 logger: logger.unwrap_or_default(),
                 modules: modules.unwrap_or_default(),
-                platform: platform.unwrap_or_else(|| default_platform()),
+                platform: platform.unwrap_or_else(default_platform),
                 timestamp: timestamp.unwrap_or_default(),
                 server_name: server_name.unwrap_or_default(),
                 release: release.unwrap_or_default(),


### PR DESCRIPTION
This PR adds clippy as linter and fixes all errors. Some warnings are overridden by allowing the specific rule. Search the changeset for `feature = "cargo-clippy"` to see all instances.