### PR TITLE
feat: Export lists of PII kinds and builtin rules

### DIFF
--- a/src/processor/builtin.rs
+++ b/src/processor/builtin.rs
@@ -5,7 +5,7 @@ use super::rule::{HashAlgorithm, Redaction, RuleSpec, RuleType};
 macro_rules! declare_builtin_rules {
     ($($rule_id:expr => $spec:expr;)*) => {
         lazy_static! {
-            pub(crate) static ref BUILTIN_RULES: BTreeMap<&'static str, &'static RuleSpec> = {
+            pub(crate) static ref BUILTIN_RULES_MAP: BTreeMap<&'static str, &'static RuleSpec> = {
                 let mut map = BTreeMap::new();
                 $(
                     map.insert($rule_id, Box::leak(Box::new($spec)) as &'static _);
@@ -13,6 +13,11 @@ macro_rules! declare_builtin_rules {
                 map
             };
         }
+
+        /// Names of all builtin rules
+        pub static BUILTIN_RULES: &[&'static str] = &[
+            $($rule_id,)*
+        ];
     }
 }
 

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -6,5 +6,6 @@ mod rule;
 
 pub mod chunks;
 
+pub use self::builtin::BUILTIN_RULES;
 pub use self::pii::*;
 pub use self::rule::*;

--- a/src/processor/pii.rs
+++ b/src/processor/pii.rs
@@ -5,30 +5,36 @@ use protocol::{Annotated, Array, Map, Meta, Value, Values};
 
 use super::chunks::{self, Chunk};
 
-/// The type of PII that's contained in the field.
-#[derive(Copy, Clone, Debug, Deserialize, Serialize, Ord, PartialOrd, Eq, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub enum PiiKind {
-    /// A freeform text potentially containing PII data.
-    Freeform,
-    /// An ip address.
-    Ip,
-    /// A user, unique device or other PII ID.
-    Id,
-    /// A username or other user identifier.
-    Username,
-    /// Hostname of a machine (server, pc or mobile device).
-    Hostname,
-    /// Sensitive PII if they ever come up in the protocol (gender, religious orientation, etc).
-    Sensitive,
-    /// First, last or real name of a person.
-    Name,
-    /// An email address.
-    Email,
-    /// Geographical location information.
-    Location,
-    /// An arbitrary structured data bag.
-    Databag,
+macro_rules! define_pii_kind {
+    ($($variant:ident($str:expr) : $doc:expr;)*) => {
+        /// The type of PII that's contained in the field.
+        #[derive(Copy, Clone, Debug, Deserialize, Serialize, Ord, PartialOrd, Eq, PartialEq)]
+        #[serde(rename_all = "snake_case")]
+        pub enum PiiKind {
+            $(
+                #[doc=$doc]
+                $variant,
+            )*
+        }
+
+        /// Names of all PII kinds
+        pub static PII_KINDS: &[&'static str] = &[
+            $($str),*
+        ];
+    }
+}
+
+define_pii_kind! {
+    Freeform("freeform"): "A freeform text potentially containing PII data.";
+    Ip("ip"): "An ip address";
+    Id("id"): "A user, unique device or other PII ID";
+    Username("username"): "A username or other user identifier";
+    Hostname("hostname"): "Hostname of a machine (server, pc or mobile device).";
+    Sensitive("sensitive"): "Sensitive PII if they ever come up in the protocol (gender, religious orientation etc.)";
+    Name("name"): "First, last or real name of a person";
+    Email("email"): "An email address";
+    Location("location"): "Geographical location information.";
+    Databag("databag"): "An arbitrary structured data bag";
 }
 
 /// The type of cap applied to the value.

--- a/src/processor/rule.rs
+++ b/src/processor/rule.rs
@@ -14,7 +14,7 @@ use sha2::{Sha256, Sha512};
 
 use protocol::{Annotated, Meta, Remark, RemarkType, Value};
 
-use super::builtin::BUILTIN_RULES;
+use super::builtin::BUILTIN_RULES_MAP;
 use super::chunks::{self, Chunk};
 use super::pii::{PiiKind, PiiProcessor, ProcessAnnotatedValue, ValueInfo};
 
@@ -580,7 +580,7 @@ impl PiiConfig {
                 spec: rule_spec,
                 cfg: self,
             })
-        } else if let Some(rule_spec) = BUILTIN_RULES.get(rule_id) {
+        } else if let Some(rule_spec) = BUILTIN_RULES_MAP.get(rule_id) {
             Some(Rule {
                 id: rule_id,
                 spec: rule_spec,


### PR DESCRIPTION
I want this for Piinguin because right now both lists are hardcoded there.